### PR TITLE
add window functionality

### DIFF
--- a/src/main/java/bridges/connect/Bridges.java
+++ b/src/main/java/bridges/connect/Bridges.java
@@ -68,9 +68,10 @@ public class Bridges {
 			title, description;
 	private static Integer MaxTitleSize = 200,
 						   MaxDescrSize = 1000;
-	private static String[] projection_options = {"cartesian", "albersusa", "equirectangular"};
+	private static String[] projection_options = {"cartesian", "albersusa", "equirectangular", "window"};
 
 	private static Boolean map_overlay = false;	// default to no map overlay
+	private static float[] window;
 	private static String display_mode = "slide"; // default to slide (vs stack)
 	private static String coord_system_type = projection_options[0];	// default to Cartesian space
 
@@ -219,7 +220,7 @@ public class Bridges {
 
 	/**
 	 * 	@param coord 	this is the desired coordinate space argument
-	 *		Options are: ['cartesian', 'albersusa', 'equirectangular'], and 'cartesian' is the default;
+	 *		Options are: ['cartesian', 'albersusa', 'equirectangular', 'window'], and 'cartesian' is the default;
 	 **/
 	public void setCoordSystemType (String coord) {
 		if (java.util.Arrays.asList(projection_options).indexOf(coord) >= 0) {
@@ -232,6 +233,19 @@ public class Bridges {
 			}
 			coord_system_type = "cartesian";
 		}
+	}
+
+	/**
+	 * 	@param x1 	minimum window x
+	 * 	@param y1 	minimum window y
+	 * 	@param x2 	maximum window x
+	 * 	@param y2 	maximum window y
+	 **/
+	public void setWindow (int x1, int y1, int x2, int y2) {
+		setWindow((float) x1, (float) y1, (float) x2, (float) y2);
+	}
+	public void setWindow (float x1, float y1, float x2, float y2) {
+		window = new float[]{x1, y1, x2, y2};
 	}
 
 	/**
@@ -481,7 +495,7 @@ public class Bridges {
 	    return assignment;
 	}
 
-    
+
 	/**
 	 *	set the assignment id
 	 *
@@ -649,7 +663,12 @@ public class Bridges {
 			QUOTE + "map_overlay" + QUOTE + COLON + map_overlay + COMMA +
 			QUOTE + "display_mode" + QUOTE + COLON + QUOTE + display_mode + QUOTE + COMMA;
 
-		// get the nodes and link representations
+		// if window is specified, add it to JSON
+		if(window != null && window.length == 4) {
+				ds_json += QUOTE + "window" + QUOTE + COLON + OPEN_BOX;
+				ds_json += window[0] + COMMA + window[1] + COMMA + window[2] + COMMA + window[3];
+		 		ds_json += CLOSE_BOX + COMMA;
+		}
 
 		if (vis_type == "Array") {
 			int dims[] = new int[3];

--- a/src/main/java/bridges/connect/Bridges.java
+++ b/src/main/java/bridges/connect/Bridges.java
@@ -71,7 +71,7 @@ public class Bridges {
 	private static String[] projection_options = {"cartesian", "albersusa", "equirectangular", "window"};
 
 	private static Boolean map_overlay = false;	// default to no map overlay
-	private static float[] window;
+	private static double[] window;
 	private static String display_mode = "slide"; // default to slide (vs stack)
 	private static String coord_system_type = projection_options[0];	// default to Cartesian space
 
@@ -242,10 +242,13 @@ public class Bridges {
 	 * 	@param y2 	maximum window y
 	 **/
 	public void setWindow (int x1, int y1, int x2, int y2) {
-		setWindow((float) x1, (float) y1, (float) x2, (float) y2);
+		setWindow((double) x1, (double) y1, (double) x2, (double) y2);
 	}
 	public void setWindow (float x1, float y1, float x2, float y2) {
-		window = new float[]{x1, y1, x2, y2};
+		setWindow((double) x1, (double) y1, (double) x2, (double) y2);
+	}
+	public void setWindow (double x1, double y1, double x2, double y2) {
+		window = new double[]{x1, y1, x2, y2};
 	}
 
 	/**


### PR DESCRIPTION
@krs-world @esaule 

Try pulling the 'window' branch and running code against the bridges-clone server:

`bridges.setServer("clone");`

Modify any graph driver **(with >100 nodes)** and add the following call:

`bridges.setCoordSystemType("window");`

and optionally specify the window:

`bridges.setWindow(-100, 100, -100, 100);`


If no window is specified, the graph-canvas script finds the 'extents' of the x and y axes, and projects them into the visualization view. If a window is specified, the script maps that window into the visualization view. 

In addition, if all nodes in the vis are fixed (have a location specified), the alpha target ('heat' of the force simulation) is set to 0, which should ease up on the rendering somewhat. Note that zooming and panning will immediately reheat the simulation and will not perform well with lots of nodes/edges in the display, as will dragging or double-clicking a node. 

Let me know what you think, and then we can merge the client code once we are happy with it. 
